### PR TITLE
Fix support for TFTrue

### DIFF
--- a/cfg/rgl_base.cfg
+++ b/cfg/rgl_base.cfg
@@ -10,7 +10,8 @@ sm_updater_check // autoupdates to prevent tampering with non custom cfgs
 
 con_timestamp "1" // timestamps console log
 sv_rcon_log "1" // turns on rcon logging
-sv_logfilename_format "rgl_conlog_%x_%X" // sets logs to get sent to the log folder instead of clumping up in one single file
+// This breaks TFTrue
+// sv_logfilename_format "rgl_conlog_%x_%X" // sets logs to get sent to the log folder instead of clumping up in one single file
 log_verbose_enable "1" // enables verbose server log
 log_verbose_interval "60" // sets verbose logging to happen every 60 seconds
 log on // turns on server log


### PR DESCRIPTION
The rgl configs were changing the default log file location. TFTrue is not smart enough to look for logs in this new location so this made every single log fail to upload. Commenting out the relevant line in the rgl configs was enough to get TFTrue working again and I can now upload logs like normal, this seems to have fixed everything on my server